### PR TITLE
add split_binary_owned rather than change signature of split_conjuction_owned

### DIFF
--- a/datafusion/core/src/physical_plan/file_format/row_filter.rs
+++ b/datafusion/core/src/physical_plan/file_format/row_filter.rs
@@ -22,7 +22,7 @@ use arrow::record_batch::RecordBatch;
 use datafusion_common::{Column, DataFusionError, Result, ScalarValue, ToDFSchema};
 use datafusion_expr::expr_rewriter::{ExprRewritable, ExprRewriter, RewriteRecursion};
 
-use datafusion_expr::{Expr, Operator};
+use datafusion_expr::Expr;
 use datafusion_optimizer::utils::split_conjunction_owned;
 use datafusion_physical_expr::execution_props::ExecutionProps;
 use datafusion_physical_expr::{create_physical_expr, PhysicalExpr};
@@ -253,7 +253,7 @@ pub fn build_row_filter(
     metadata: &ParquetMetaData,
     reorder_predicates: bool,
 ) -> Result<Option<RowFilter>> {
-    let predicates = split_conjunction_owned(expr, Operator::And);
+    let predicates = split_conjunction_owned(expr);
 
     let mut candidates: Vec<FilterCandidate> = predicates
         .into_iter()

--- a/datafusion/optimizer/src/filter_push_down.rs
+++ b/datafusion/optimizer/src/filter_push_down.rs
@@ -14,7 +14,7 @@
 
 //! Filter Push Down optimizer rule ensures that filters are applied as early as possible in the plan
 
-use crate::utils::{split_conjunction_owned, CnfHelper};
+use crate::utils::{split_binary_owned, CnfHelper};
 use crate::{utils, OptimizerConfig, OptimizerRule};
 use datafusion_common::{Column, DFSchema, DataFusionError, Result};
 use datafusion_expr::{
@@ -542,14 +542,14 @@ fn optimize(plan: &LogicalPlan, mut state: State) -> Result<LogicalPlan> {
                 let filter_cnf =
                     filter.predicate().clone().rewrite(&mut CnfHelper::new());
                 match filter_cnf {
-                    Ok(ref expr) => split_conjunction_owned(expr.clone(), Operator::And),
+                    Ok(ref expr) => split_binary_owned(expr.clone(), Operator::And),
                     Err(e) => {
                         error!("Fail at CnfHelper rewrite: {}.", e);
-                        split_conjunction_owned(filter.predicate().clone(), Operator::And)
+                        split_binary_owned(filter.predicate().clone(), Operator::And)
                     }
                 }
             } else {
-                split_conjunction_owned(filter.predicate().clone(), Operator::And)
+                split_binary_owned(filter.predicate().clone(), Operator::And)
             };
 
             predicates


### PR DESCRIPTION

# Which issue does this PR close?

Proposed changes to https://github.com/apache/arrow-datafusion/pull/3903 

Note this targets @Ted-Jiang 's fork

 # Rationale for this change
I think conjunction implies `AND` so it should not take `Operator` too

# What changes are included in this PR?
1. Add back `split_conjunction_owned`
2. Add a `split_binary_owned` that does take an `Operator`

# Are there any user-facing changes?
Changes to the above APIs