### PR TITLE
Reduce cloneing in ApproxPercentileAccumulator

### DIFF
--- a/datafusion/physical-expr/src/aggregate/approx_percentile_cont.rs
+++ b/datafusion/physical-expr/src/aggregate/approx_percentile_cont.rs
@@ -284,9 +284,8 @@ impl ApproxPercentileAccumulator {
     }
 
     pub(crate) fn merge_digests(&mut self, digests: &[TDigest]) {
-        let mut input_digests = digests.to_vec();
-        input_digests.push(self.digest.clone());
-        self.digest = TDigest::merge_digests(input_digests.as_slice());
+        let digests = digests.iter().chain(std::iter::once(&self.digest));
+        self.digest = TDigest::merge_digests(digests)
     }
 
     pub(crate) fn convert_to_float(values: &ArrayRef) -> Result<Vec<f64>> {

--- a/datafusion/physical-expr/src/aggregate/tdigest.rs
+++ b/datafusion/physical-expr/src/aggregate/tdigest.rs
@@ -370,7 +370,10 @@ impl TDigest {
     }
 
     // Merge multiple T-Digests
-    pub(crate) fn merge_digests(digests: &[TDigest]) -> TDigest {
+    pub(crate) fn merge_digests<'a>(
+        digests: impl IntoIterator<Item = &'a TDigest>,
+    ) -> TDigest {
+        let digests = digests.into_iter().collect::<Vec<_>>();
         let n_centroids: usize = digests.iter().map(|d| d.centroids.len()).sum();
         if n_centroids == 0 {
             return TDigest::default();


### PR DESCRIPTION
Suggested improvement to https://github.com/apache/arrow-datafusion/pull/10056 to avoid some clones

Note this PR targets https://github.com/apache/arrow-datafusion/pull/10056